### PR TITLE
Update 1CH-HCI-BCI-Serial.ino

### DIFF
--- a/1CH-HCI-BCI-Serial/1CH-HCI-BCI-Serial.ino
+++ b/1CH-HCI-BCI-Serial/1CH-HCI-BCI-Serial.ino
@@ -38,7 +38,7 @@
 #include <Arduino.h>
 #include "esp_dsp.h"
 
-#define DEBUG  // Uncomment this line to enable debugging
+// #define DEBUG  // Uncomment this line to enable debugging
 
 // ----------------- USER CONFIGURATION -----------------
 #define SAMPLE_RATE       512          // samples per second


### PR DESCRIPTION
Disabled debugging by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled debug logging by default to provide cleaner serial output during normal use. BetaPower/EOG/EMG debug prints are suppressed unless explicitly re-enabled, reducing noise and potential performance impact. No functional behavior has changed; advanced users can locally enable verbose diagnostics if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->