### PR TITLE
refactor MAC pairing, serial lock, and motor control

### DIFF
--- a/BLE-BCI-Car-Remote/BLE-BCI-Car-Remote.ino
+++ b/BLE-BCI-Car-Remote/BLE-BCI-Car-Remote.ino
@@ -301,10 +301,10 @@ void printMacAddress() {
   // BLEDevice must be init'd before calling getAddress()
   String mac = BLEDevice::getAddress().toString().c_str();
   Serial.println("============================================");
-  Serial.println("  NPG Lite MAC Address (copy this value)   ");
+  Serial.println("  NPG Lite MAC Address (copy this line)   ");
   Serial.println("============================================");
-  Serial.println(mac);
-  Serial.println("Paste the MAC above into the car firmware  ");
+  Serial.println("Set MAC "+mac);
+  Serial.println("Paste the line above into the car firmware  ");
   Serial.println("when prompted, then reset the car.         ");
   Serial.println("============================================");
 }

--- a/BLE-BCI-Car/BLE-BCI-Car.ino
+++ b/BLE-BCI-Car/BLE-BCI-Car.ino
@@ -13,7 +13,7 @@
 
 // Copyright (c) 2025 Aman Maheshwari     - Aman@upsidedownlabs.tech
 // Copyright (c) 2024-2025 Krishnanshu Mittal - krishnanshu@upsidedownlabs.tech
-// Copyright (c) 2024-2025 Dee.pak Khatri      - deepak@upsidedownlabs.tech
+// Copyright (c) 2024-2025 Deepak Khatri      - deepak@upsidedownlabs.tech
 // Copyright (c) 2024-2025 Upside Down Labs   - contact@upsidedownlabs.tech
 
 // At Upside Down Labs, we create open-source DIY neuroscience hardware and software.
@@ -103,14 +103,14 @@ void updateSerialLock() {
   bool hostConnected = (bool)Serial;
 
   if (hostConnected && !serialLocked) {
-    serialLocked = true;
+    serialLocked  = true;
+    activeCommand = 255;   // reset so BLE resumes correctly after monitor closes
     stopMotors();
     Serial.println("[SERIAL LOCK] Serial Monitor detected - motor commands disabled.");
     Serial.println("Close Serial Monitor to enable BLE motor control.");
     printHelp();
   } else if (!hostConnected && serialLocked) {
     serialLocked = false;
-    // Serial Monitor is gone - cannot print
   }
 }
 

--- a/BLE-BCI-Car/BLE-BCI-Car.ino
+++ b/BLE-BCI-Car/BLE-BCI-Car.ino
@@ -13,7 +13,7 @@
 
 // Copyright (c) 2025 Aman Maheshwari     - Aman@upsidedownlabs.tech
 // Copyright (c) 2024-2025 Krishnanshu Mittal - krishnanshu@upsidedownlabs.tech
-// Copyright (c) 2024-2025 Deepak Khatri      - deepak@upsidedownlabs.tech
+// Copyright (c) 2024-2025 Dee.pak Khatri      - deepak@upsidedownlabs.tech
 // Copyright (c) 2024-2025 Upside Down Labs   - contact@upsidedownlabs.tech
 
 // At Upside Down Labs, we create open-source DIY neuroscience hardware and software.
@@ -26,31 +26,47 @@
  Firmware: https://github.com/mo-thunderz/Esp32BlePart2
  YouTube video: https://www.youtube.com/watch?v=s3yoZa6kzus
 */
+
+// ================================================================
+//  SERIAL LOCK BEHAVIOUR
+//
+//  When a Serial Monitor is connected (USB active), BLE motor
+//  commands are IGNORED - the car stays still.
+//  You can still use Serial to configure the MAC:
+//
+//    set mac xx:xx:xx:xx:xx:xx  -> save & connect to that MAC
+//    remove mac                 -> clear saved MAC
+//    status                     -> print current status
+//
+//  Disconnect Serial Monitor to allow BLE motor control.
+//
+// ================================================================
+
+// ================================================================
+//  MAC PAIRING
+//
+//  Type in Serial Monitor:
+//    set mac xx:xx:xx:xx:xx:xx
+//  The MAC is saved to flash and reused on every reboot.
+//
+//  To change/remove it:
+//    remove mac   (then set a new one with set mac)
+// ================================================================
+
 #include <Arduino.h>
 #include "BLEDevice.h"
 #include <Preferences.h>   // ESP32 NVS - survives power cycles
 
-// ================================================================
-//  MAC PAIRING - Automatic via Serial on first boot
-//
-//  First boot (or after clearing NVS):
-//    1. Flash ble_server_remote.ino to the NPG Lite and open its
-//       Serial Monitor. Copy the MAC address it prints.
-//    2. Flash this firmware to the car, open its Serial Monitor.
-//    3. Paste the MAC when prompted and press Enter.
-//    4. The MAC is saved to flash - no re-entry needed on reboot.
-//
-//  To reset the saved MAC: type "RESET" (without quotes) in the
-//  car's Serial Monitor while it is waiting for commands, then
-//  reset the board. You will be prompted for a new MAC.
-// ================================================================
-
-// BLE UUIDs - must match server
+// ---------------------------------------------------------------
+//  BLE UUIDs - must match server
+// ---------------------------------------------------------------
 static BLEUUID serviceUUID("4fafc201-1fb5-459e-8fcc-c5c9c331914b");
 static BLEUUID charUUID_1 ("beb5483e-36e1-4688-b7f5-ea07361b26a8");
 static BLEUUID charUUID_2 ("1c95d5e3-d8f7-413a-bf3d-7a2e5d7be87e");
 
-// Motor pins (MX1508: IN1-IN4)
+// ---------------------------------------------------------------
+//  Motor pins (MX1508: IN1-IN4)
+// ---------------------------------------------------------------
 const int PIN_L_FWD = 0;
 const int PIN_L_BWD = 1;
 const int PIN_R_FWD = 21;
@@ -63,37 +79,56 @@ const int CH_R_FWD = 2;
 const int CH_R_BWD = 3;
 
 // PWM config
-const int PWM_FREQ = 25000;
-const int PWM_RES  = 8;
-const int PWM_MAX  = 220;
+const int PWM_FREQ  = 25000;
+const int PWM_RES   = 8;        // 8-bit resolution -> 0-255
+const int MOTOR_PWM = 200;      // single speed for all motor moves (0-255)
 
-// Soft-start ramp
-const int RAMP_START    = 220;
-const int RAMP_STEPS    = 0;
-const int RAMP_DELAY_MS = 12;
 
-// Beep config
-const int BEEP_FREQ   = 7000;
-const int BEEP_DUTY   = 128;
-const int BEEP_ON_MS  = 120;
-const int BEEP_OFF_MS = 100;
+// ---------------------------------------------------------------
+//  Forward declarations
+// ---------------------------------------------------------------
+void stopMotors();
+void printHelp();
+
+// ---------------------------------------------------------------
+//  Serial-lock detection
+//
+//  On ESP32 with USB CDC, casting Serial to bool returns true only
+//  when a host (Serial Monitor) is actively connected.
+//  Lock follows actual connection state - no timeout needed.
+// ---------------------------------------------------------------
+bool serialLocked = false;
+
+void updateSerialLock() {
+  bool hostConnected = (bool)Serial;
+
+  if (hostConnected && !serialLocked) {
+    serialLocked = true;
+    stopMotors();
+    Serial.println("[SERIAL LOCK] Serial Monitor detected - motor commands disabled.");
+    Serial.println("Close Serial Monitor to enable BLE motor control.");
+    printHelp();
+  } else if (!hostConnected && serialLocked) {
+    serialLocked = false;
+    // Serial Monitor is gone - cannot print
+  }
+}
 
 // ---------------------------------------------------------------
 //  Preferences (NVS) - stores MAC across power cycles
 // ---------------------------------------------------------------
 Preferences prefs;
-const char* PREFS_NS  = "bci-car";   // namespace
-const char* PREFS_KEY = "server_mac"; // key for the MAC string
+const char* PREFS_NS  = "bci-car";
+const char* PREFS_KEY = "server_mac";
 
-String targetMac = "";  // populated in setup() from NVS or Serial
+String targetMac = "";
 
 // ---------------------------------------------------------------
 //  BLE state
 // ---------------------------------------------------------------
-static boolean doConnect    = false;
-static boolean connected    = false;
-static boolean doScan       = false;
-static boolean justConnected = false;
+static boolean doConnect     = false;
+static boolean connected     = false;
+static boolean doScan        = false;
 
 static BLEAdvertisedDevice*     myDevice      = nullptr;
 static BLERemoteCharacteristic* pRemoteChar_1 = nullptr;
@@ -113,76 +148,46 @@ void stopMotors() {
   pwmWrite(PIN_R_FWD, 0); pwmWrite(PIN_R_BWD, 0);
 }
 
-void softStartBoth(bool dirL, bool dirR, int dutyL, int dutyR) {
-  stopMotors();
-  int aPin_L = dirL ? PIN_L_FWD : PIN_L_BWD;
-  int iPin_L = dirL ? PIN_L_BWD : PIN_L_FWD;
-  int aPin_R = dirR ? PIN_R_FWD : PIN_R_BWD;
-  int iPin_R = dirR ? PIN_R_BWD : PIN_R_FWD;
-  pwmWrite(iPin_L, 0); pwmWrite(iPin_R, 0);
-
-  // RAMP_STEPS = 0 means instant start - guard against divide-by-zero
-  if (RAMP_STEPS > 0) {
-    int stepL = max(1, (dutyL - RAMP_START) / RAMP_STEPS);
-    int stepR = max(1, (dutyR - RAMP_START) / RAMP_STEPS);
-    int curL  = RAMP_START, curR = RAMP_START;
-    while (curL < dutyL || curR < dutyR) {
-      if (curL < dutyL) curL = min(curL + stepL, dutyL);
-      if (curR < dutyR) curR = min(curR + stepR, dutyR);
-      pwmWrite(aPin_L, curL);
-      pwmWrite(aPin_R, curR);
-      delay(RAMP_DELAY_MS);
-    }
-  }
-  pwmWrite(aPin_L, dutyL);
-  pwmWrite(aPin_R, dutyR);
-}
-
-void softStartOne(int fwdPin, int bwdPin, bool forward, int targetDuty) {
-  int aPin = forward ? fwdPin : bwdPin;
-  int iPin = forward ? bwdPin : fwdPin;
-  pwmWrite(iPin, 0);
-  if (RAMP_STEPS > 0) {
-    int step = max(1, (targetDuty - RAMP_START) / RAMP_STEPS);
-    for (int d = RAMP_START; d < targetDuty; d += step) {
-      pwmWrite(aPin, d);
-      delay(RAMP_DELAY_MS);
-    }
-  }
-  pwmWrite(aPin, targetDuty);
-}
-
 // ---------------------------------------------------------------
-//  Beep
+//  Movement  (direct PWM write - no ramp)
 // ---------------------------------------------------------------
-void beepConnect() {
-  ledcAttachChannel(PIN_L_FWD, BEEP_FREQ, PWM_RES, CH_L_FWD);
-  ledcAttachChannel(PIN_R_FWD, BEEP_FREQ, PWM_RES, CH_R_FWD);
-  pwmWrite(PIN_L_BWD, 0); pwmWrite(PIN_R_BWD, 0);
-  for (int b = 0; b < 2; b++) {
-    pwmWrite(PIN_L_FWD, BEEP_DUTY); pwmWrite(PIN_R_FWD, BEEP_DUTY);
-    delay(BEEP_ON_MS);
-    pwmWrite(PIN_L_FWD, 0); pwmWrite(PIN_R_FWD, 0);
-    if (b == 0) delay(BEEP_OFF_MS);
-  }
-  ledcAttachChannel(PIN_L_FWD, PWM_FREQ, PWM_RES, CH_L_FWD);
-  ledcAttachChannel(PIN_R_FWD, PWM_FREQ, PWM_RES, CH_R_FWD);
-  stopMotors();
-}
-
-// ---------------------------------------------------------------
-//  Movement
-// ---------------------------------------------------------------
-void driveForward()  { Serial.println("fwd");   softStartBoth(true,  true,  PWM_MAX, PWM_MAX); }
-void driveBackward() { Serial.println("bwd");   softStartBoth(false, false, PWM_MAX, PWM_MAX); }
-void turnLeft()      { Serial.println("left");  stopMotors(); softStartOne(PIN_R_FWD, PIN_R_BWD, true, PWM_MAX); }
-void turnRight()     { Serial.println("right"); stopMotors(); softStartOne(PIN_L_FWD, PIN_L_BWD, true, PWM_MAX); }
-
 uint32_t activeCommand = 255;
+
+void driveForward() {
+  pwmWrite(PIN_L_BWD, 0);      pwmWrite(PIN_R_BWD, 0);
+  pwmWrite(PIN_L_FWD, MOTOR_PWM); pwmWrite(PIN_R_FWD, MOTOR_PWM);
+  Serial.println("fwd");
+}
+
+void driveBackward() {
+  pwmWrite(PIN_L_FWD, 0);      pwmWrite(PIN_R_FWD, 0);
+  pwmWrite(PIN_L_BWD, MOTOR_PWM); pwmWrite(PIN_R_BWD, MOTOR_PWM);
+  Serial.println("bwd");
+}
+
+void turnLeft() {
+  stopMotors();
+  pwmWrite(PIN_R_BWD, 0);
+  pwmWrite(PIN_R_FWD, MOTOR_PWM);
+  Serial.println("left");
+}
+
+void turnRight() {
+  stopMotors();
+  pwmWrite(PIN_L_BWD, 0);
+  pwmWrite(PIN_L_FWD, MOTOR_PWM);
+  Serial.println("right");
+}
 
 void applyCommand(uint32_t cmd) {
   if (cmd == activeCommand) return;
   activeCommand = cmd;
+
+  if (serialLocked) {
+    Serial.println("[SERIAL LOCK] BLE cmd " + String(cmd) + " ignored (Serial Monitor active).");
+    return;
+  }
+
   switch (cmd) {
     case 1:  turnLeft();      break;
     case 2:  turnRight();     break;
@@ -209,7 +214,7 @@ class MyClientCallback : public BLEClientCallbacks {
   void onConnect(BLEClient* pclient) {}
   void onDisconnect(BLEClient* pclient) {
     connected     = false;
-    doScan        = true;
+    doScan        = (targetMac.length() > 0);  // re-scan only if MAC is set
     activeCommand = 255;
     stopMotors();
     Serial.println("BLE disconnected");
@@ -240,8 +245,7 @@ bool connectToServer() {
           & connectCharacteristic(svc, pRemoteChar_2, charUUID_2);
   if (!ok) { pClient->disconnect(); return false; }
 
-  connected     = true;
-  justConnected = true;
+  connected = true;
   return true;
 }
 
@@ -249,12 +253,15 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
   void onResult(BLEAdvertisedDevice dev) {
     if (!dev.haveServiceUUID() || !dev.isAdvertisingService(serviceUUID)) return;
 
+    // No MAC set -> never connect to anything
+    if (targetMac.length() == 0) return;
+
     String found  = dev.getAddress().toString().c_str();
     String target = targetMac;
     found.toLowerCase(); target.toLowerCase();
 
-    // If targetMac is empty or placeholder, connect to any matching server
-    if (target.length() > 0 && target != "xx:xx:xx:xx:xx:xx" && found != target) return;
+    // Only connect if MAC matches exactly
+    if (found != target) return;
 
     BLEDevice::getScan()->stop();
     if (myDevice) delete myDevice;
@@ -266,79 +273,53 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
 };
 
 // ---------------------------------------------------------------
-//  MAC management - load from NVS or prompt user over Serial
+//  MAC helpers
 // ---------------------------------------------------------------
-
-// Validate that a string looks like a MAC address (xx:xx:xx:xx:xx:xx)
 bool isValidMac(const String &mac) {
   if (mac.length() != 17) return false;
   for (int i = 0; i < 17; i++) {
     if (i % 3 == 2) {
       if (mac[i] != ':') return false;
     } else {
-      char c = tolower(mac[i]);
-      if (!isxdigit(c)) return false;
+      if (!isxdigit(tolower(mac[i]))) return false;
     }
   }
   return true;
 }
 
-// Prompt the user to enter a MAC over Serial and save it to NVS
-String promptAndSaveMac() {
-  Serial.println("============================================");
-  Serial.println("  Car First-Boot MAC Setup                 ");
-  Serial.println("============================================");
-  Serial.println("Open the NPG Lite Serial Monitor and copy  ");
-  Serial.println("the MAC address it printed on startup.     ");
-  Serial.println("Paste it here and press Enter:             ");
-  Serial.println("  Format: xx:xx:xx:xx:xx:xx (lowercase)    ");
-  Serial.println("============================================");
-
-  String input = "";
-  while (true) {
-    // Wait until something arrives
-    while (!Serial.available()) delay(10);
-
-    input = Serial.readStringUntil('\n');
-    input.trim();
-    input.toLowerCase();
-
-    if (input.length() == 0) {
-      Serial.println("Empty input - please try again:");
-      continue;
-    }
-    if (!isValidMac(input)) {
-      Serial.println("Invalid format. Expected xx:xx:xx:xx:xx:xx - please try again:");
-      continue;
-    }
-    break;
-  }
-
-  // Save to NVS
-  prefs.begin(PREFS_NS, false);          // open read-write
-  prefs.putString(PREFS_KEY, input);
-  prefs.end();
-
-  Serial.println("Saved MAC: " + input);
-  Serial.println("This will be used automatically on future boots.");
-  Serial.println("To change it, type RESET in Serial Monitor and reset the board.");
-  return input;
-}
-
-// Load MAC from NVS; return empty string if not set
 String loadMac() {
-  prefs.begin(PREFS_NS, true);           // open read-only
+  prefs.begin(PREFS_NS, true);
   String mac = prefs.getString(PREFS_KEY, "");
   prefs.end();
   return mac;
 }
 
-// Erase saved MAC from NVS
+void saveMac(const String &mac) {
+  prefs.begin(PREFS_NS, false);
+  prefs.putString(PREFS_KEY, mac);
+  prefs.end();
+}
+
 void clearMac() {
   prefs.begin(PREFS_NS, false);
   prefs.remove(PREFS_KEY);
   prefs.end();
-  Serial.println("Saved MAC cleared. Restart the board to enter a new MAC.");
+}
+
+// ---------------------------------------------------------------
+//  Print help
+// ---------------------------------------------------------------
+void printHelp() {
+  Serial.println("============================================");
+  Serial.println("  BCI Car Serial Commands                  ");
+  Serial.println("  set mac xx:xx:xx:xx:xx:xx  - pair to MAC ");
+  Serial.println("  remove mac                 - clear MAC   ");
+  Serial.println("  status                     - show info   ");
+  Serial.println("============================================");
+  Serial.println("NOTE: While Serial Monitor is open, BLE    ");
+  Serial.println("motor commands are DISABLED for safety.    ");
+  Serial.println("Close Serial Monitor to drive the car.     ");
+  Serial.println("============================================");
 }
 
 // ---------------------------------------------------------------
@@ -346,7 +327,7 @@ void clearMac() {
 // ---------------------------------------------------------------
 void setup() {
   Serial.begin(115200);
-  delay(500);  // give Serial time to settle before printing
+  delay(500);
 
   // Motor LEDC setup
   ledcAttachChannel(PIN_L_FWD, PWM_FREQ, PWM_RES, CH_L_FWD);
@@ -357,30 +338,31 @@ void setup() {
 
   BLEDevice::init("");
 
-  // --- MAC resolution ---
+  // Load saved MAC
   String savedMac = loadMac();
-
   if (savedMac.length() > 0 && isValidMac(savedMac)) {
-    // Use the saved MAC
     targetMac = savedMac;
-    Serial.println("============================================");
     Serial.println("Loaded saved MAC: " + targetMac);
-    Serial.println("Type RESET and press Enter to change it.   ");
-    Serial.println("============================================");
   } else {
-    // No valid MAC saved - prompt the user
-    targetMac = promptAndSaveMac();
+    Serial.println("No MAC saved. Use: set mac xx:xx:xx:xx:xx:xx");
   }
 
-  Serial.println("Pairing to: " + targetMac);
-  Serial.println("Scanning for NPG Lite...");
+  printHelp();
 
   BLEScan* scan = BLEDevice::getScan();
   scan->setAdvertisedDeviceCallbacks(new MyAdvertisedDeviceCallbacks());
   scan->setInterval(1349);
   scan->setWindow(449);
   scan->setActiveScan(true);
-  scan->start(5, false);
+
+  if (targetMac.length() > 0) {
+    Serial.println("Scanning for: " + targetMac);
+    doScan = true;
+    scan->start(5, false);
+  } else {
+    Serial.println("No MAC set - not scanning. Use: set mac xx:xx:xx:xx:xx:xx");
+    doScan = false;
+  }
 }
 
 // ---------------------------------------------------------------
@@ -391,39 +373,80 @@ const unsigned long RECONNECT_INTERVAL = 3000;
 
 void loop() {
 
+  // --- Serial lock: check USB CDC connection state ---
+  updateSerialLock();
+
   // --- Serial command handler ---
-  // Allows "RESET" to clear the stored MAC while running
   if (Serial.available()) {
     String cmd = Serial.readStringUntil('\n');
     cmd.trim();
-    if (cmd.equalsIgnoreCase("RESET")) {
+    String cmdLower = cmd;
+    cmdLower.toLowerCase();
+
+    // -- set mac xx:xx:xx:xx:xx:xx ------------------------------------
+    if (cmdLower.startsWith("set mac ")) {
+      String newMac = cmd.substring(8);
+      newMac.trim();
+      newMac.toLowerCase();
+
+      if (isValidMac(newMac)) {
+        saveMac(newMac);
+        targetMac = newMac;
+        Serial.println("MAC set to: " + targetMac);
+        if (pClient && pClient->isConnected()) pClient->disconnect();
+        connected     = false;
+        activeCommand = 255;
+        doConnect     = false;
+        doScan        = true;
+        Serial.println("Scanning for: " + targetMac);
+        BLEDevice::getScan()->start(5, false);
+      } else {
+        Serial.println("Invalid MAC. Format: set mac xx:xx:xx:xx:xx:xx");
+      }
+
+    // -- remove mac ---------------------------------------------------
+    } else if (cmdLower == "remove mac") {
       clearMac();
-      // Disconnect if connected
+      targetMac = "";
+      BLEDevice::getScan()->stop();
+      doScan    = false;
+      doConnect = false;
       if (pClient && pClient->isConnected()) pClient->disconnect();
-      delay(500);
-      ESP.restart();  // restart so promptAndSaveMac() runs on next boot
+      connected     = false;
+      activeCommand = 255;
+      stopMotors();
+      Serial.println("MAC cleared. Scanning stopped.");
+      Serial.println("Car will NOT connect to any device until a MAC is set.");
+      Serial.println("Use: set mac xx:xx:xx:xx:xx:xx");
+
+    // -- status -------------------------------------------------------
+    } else if (cmdLower == "status") {
+      Serial.println("--------------------------------------------");
+      Serial.println("MAC      : " + (targetMac.length() > 0 ? targetMac : "(not set)"));
+      Serial.println("BLE      : " + String(connected ? "Connected" : "Disconnected"));
+      Serial.println("Motors   : " + String(serialLocked ? "LOCKED (Serial active)" : "Enabled"));
+      Serial.println("PWM      : " + String(MOTOR_PWM) + " / 255");
+      Serial.println("--------------------------------------------");
+
+    // -- help / unknown -----------------------------------------------
+    } else {
+      printHelp();
     }
   }
 
-  // Connect to server when found
+  // --- Connect to BLE server when found ---
   if (doConnect) {
     doConnect = false;
     if (connectToServer()) {
       Serial.println("Connected to NPG Lite");
     } else {
       Serial.println("Connect failed, retrying...");
-      doScan = true;
+      doScan = (targetMac.length() > 0);
     }
   }
 
-  // Beep once right after connection
-  if (justConnected) {
-    justConnected = false;
-    beepConnect();
-  }
-
-  // Re-scan while not connected
-  if (!connected && doScan) {
+  // --- Re-scan while not connected (only if MAC is set) ---
+  if (!connected && doScan && targetMac.length() > 0) {
     unsigned long now = millis();
     if (now - lastReconnect >= RECONNECT_INTERVAL) {
       lastReconnect = now;
@@ -431,14 +454,14 @@ void loop() {
     }
   }
 
-  // Dispatch motor command
+  // --- Dispatch motor command (blocked if serialLocked) ---
   if (newCommand) {
     newCommand = false;
     applyCommand(currentCommand);
   }
 
-  // Watchdog
-  if (!connected && !doScan) doScan = true;
+  // Watchdog - only re-enable scan if MAC is set
+  if (!connected && !doScan && targetMac.length() > 0) doScan = true;
 
   delay(10);
 }


### PR DESCRIPTION
- Replace first-boot MAC prompt with `set mac xx:xx:xx:xx:xx:xx` serial command
- Add `remove mac` and `status` serial commands
- Add serial lock: when Serial Monitor is open (USB CDC detected), BLE motor commands are blocked; lock releases when monitor is closed
- Replace soft-start ramp (softStartBoth/softStartOne) with single MOTOR_PWM constant and direct PWM writes for simpler motor control
- Remove beepConnect() and justConnected flag (motors do not produce audible sound )
- Watchdog and reconnect logic now guard against scanning when no MAC is set

@lorforlinux , please review and merge it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Motors now stop and motor commands are disabled when a USB serial monitor is connected.
  * MAC pairing is strict to prevent unintended connections; BLE reconnection only occurs when a valid MAC is set.
  * Removed the runtime first-boot interactive MAC prompt.

* **New Features**
  * Added serial commands to set, remove, and view MAC address.

* **Documentation**
  * Updated serial prompt text and copy for MAC setup and paste instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/upsidedownlabs/NPG-Lite-Arduino-Firmware/pull/30)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->