### PR TITLE
Fix: activeCommand out-of-scope compilation error

### DIFF
--- a/BLE-BCI-Car/BLE-BCI-Car.ino
+++ b/BLE-BCI-Car/BLE-BCI-Car.ino
@@ -98,6 +98,7 @@ void printHelp();
 //  Lock follows actual connection state - no timeout needed.
 // ---------------------------------------------------------------
 bool serialLocked = false;
+uint32_t activeCommand = 255;
 
 void updateSerialLock() {
   bool hostConnected = (bool)Serial;
@@ -151,7 +152,6 @@ void stopMotors() {
 // ---------------------------------------------------------------
 //  Movement  (direct PWM write - no ramp)
 // ---------------------------------------------------------------
-uint32_t activeCommand = 255;
 
 void driveForward() {
   pwmWrite(PIN_L_BWD, 0);      pwmWrite(PIN_R_BWD, 0);


### PR DESCRIPTION
## Fix
- Moved `uint32_t activeCommand = 255;` above `updateSerialLock()`

@lorforlinux, Please review and merge it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal code structure with no impact to functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/upsidedownlabs/NPG-Lite-Arduino-Firmware/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->